### PR TITLE
Handle a quirk in helga's command regex parsing

### DIFF
--- a/helga_karma/__init__.py
+++ b/helga_karma/__init__.py
@@ -1,4 +1,4 @@
-VERSION = (1, 0, 0)
+VERSION = (1, 0, 1)
 
 
 __version__ = '.'.join([str(v) for v in VERSION])

--- a/helga_karma/plugin.py
+++ b/helga_karma/plugin.py
@@ -192,7 +192,7 @@ def unalias(requested_by, nick1, nick2):
     return format_message('unlinked', usera=nick1, userb=nick2)
 
 
-@command('karma', aliases=['k', 't', 'thanks', 'm', 'motivate', 'alias', 'unalias'],
+@command('karma', aliases=['k', 'thanks', 'motivate', 't', 'm', 'alias', 'unalias'],
          help=('Give and receive karma. Usage: helga ('
                'k[arma] [(top [num] | [details] [for] [nick] | [un]alias <nick1> <nick2>)] | '
                '(t[hanks] | m[otivate]) <nick>)'))


### PR DESCRIPTION
Long versions of the commands should precede the short versions because helga constructs the command regex like: (t|thanks)(.*)

I'll file an issue about this in helga core
